### PR TITLE
Remove date field from pair and reward

### DIFF
--- a/app/src/androidTest/java/api/TestParse.java
+++ b/app/src/androidTest/java/api/TestParse.java
@@ -156,12 +156,9 @@ public class TestParse {
     public void canParseRewardResponse() throws IOException{
         addRewardResponse();
         RewardResponse r = ResponsePojoConverter.rewardToRewardResponse(
-                new Reward(
-                        Long.toString(System.currentTimeMillis()/1000),
-                        RewardType.PIZZA));
+                new Reward(RewardType.PIZZA));
         RewardResponse res = rewardDao.addReward(r).execute().body().get(0);
 
-        assertThat(res.getDate(), equalTo("10000"));
         assertThat(res.getRewardType(), equalTo(RewardType.PIZZA));
         assertThat(res.getUsedReward(), equalTo(false));
     }
@@ -189,11 +186,10 @@ public class TestParse {
     @Test
     public void canParsePairResponse() throws IOException{
         addPairResponse();
-        Pair p = new Pair("esog", "ohald", "10000000");
+        Pair p = new Pair("esog", "ohald");
         PairResponse r = pairDao.insertPair(
                 ResponsePojoConverter.pairToPairResponse(p)).execute().body();
 
-        assertThat(r.getDate(), equalTo(p.getDate()));
         assertThat(r.getPerson1(), equalTo(p.getPerson1()));
         assertThat(r.getPerson2(), equalTo(p.getPerson2()));
     }

--- a/app/src/main/java/com/bettertogether/app/DataManager.java
+++ b/app/src/main/java/com/bettertogether/app/DataManager.java
@@ -157,10 +157,8 @@ public class DataManager {
 
 
     private void addReward(RewardType type) {
-        long unixTimestamp = System.currentTimeMillis();
-
         RewardResponse res = ResponsePojoConverter.rewardToRewardResponse(
-                new Reward(Long.toString(unixTimestamp), type));
+                new Reward(type));
 
         rewardDao.addReward(res).enqueue(
                 new CallbackWrapper<>((throwable, response) -> {

--- a/app/src/main/java/com/bettertogether/app/Pair.java
+++ b/app/src/main/java/com/bettertogether/app/Pair.java
@@ -4,16 +4,11 @@ public class Pair {
 
     private String person1;
     private String person2;
-    private String date;
 
-    public Pair(String date) {
-        this.date = date;
-    }
 
-    public Pair(String person1, String person2, String date) {
+    public Pair(String person1, String person2) {
         this.person1 = person1;
         this.person2 = person2;
-        this.date = date;
     }
 
     public String getPerson1() {
@@ -30,14 +25,6 @@ public class Pair {
 
     public void setPerson2(String person2) {
         this.person2 = person2;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public void setDate(String date) {
-        this.date = date;
     }
 
 }

--- a/app/src/main/java/com/bettertogether/app/Reward.java
+++ b/app/src/main/java/com/bettertogether/app/Reward.java
@@ -3,29 +3,17 @@ import db.RewardType;
 
 public class Reward {
 
-    private String date;
-
     private RewardType type;
 
     private boolean usedReward;
 
-    public Reward(String date, RewardType type) {
-        this.date = date;
+    public Reward(RewardType type) {
         this.type = type;
         this.usedReward = false;
     }
 
-
     public boolean isUsedReward() {
         return usedReward;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public void setDate(String date) {
-        this.date = date;
     }
 
     public RewardType getType() {

--- a/app/src/main/java/com/bettertogether/app/fragments/UserListFragment.java
+++ b/app/src/main/java/com/bettertogether/app/fragments/UserListFragment.java
@@ -169,11 +169,9 @@ public class UserListFragment extends Fragment implements DataUpdateListener {
             return;
         }
 
-        long unixTimestamp = System.currentTimeMillis();
-        Pair pair = new Pair(Long.toString(unixTimestamp));
-
-        pair.setPerson1(manager.getActiveUsers().get(selectedItems.get(0)).getUsername());
-        pair.setPerson2(manager.getActiveUsers().get(selectedItems.get(1)).getUsername());
+        Pair pair = new Pair(
+                manager.getActiveUsers().get(selectedItems.get(0)).getUsername(),
+                manager.getActiveUsers().get(selectedItems.get(1)).getUsername());
         manager.addPair(pair);
         resetSelectedPersons();
         Toast.makeText(getContext(),

--- a/app/src/main/java/db/responseparsers/PairResponse.java
+++ b/app/src/main/java/db/responseparsers/PairResponse.java
@@ -1,5 +1,6 @@
 package db.responseparsers;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -16,6 +17,8 @@ public class PairResponse {
     private String person1;
     @JsonProperty("person2")
     private String person2;
+
+    @JsonIgnore
     @JsonProperty("date")
     private String date;
 
@@ -38,16 +41,5 @@ public class PairResponse {
     public void setPerson2(String person2) {
         this.person2 = person2;
     }
-
-    @JsonProperty("date")
-    public String getDate() {
-        return date;
-    }
-
-    @JsonProperty("date")
-    public void setDate(String date) {
-        this.date = date;
-    }
-
 
 }

--- a/app/src/main/java/db/responseparsers/ResponsePojoConverter.java
+++ b/app/src/main/java/db/responseparsers/ResponsePojoConverter.java
@@ -14,12 +14,11 @@ public class ResponsePojoConverter {
         PairResponse r = new PairResponse();
         r.setPerson1(p.getPerson1());
         r.setPerson2(p.getPerson2());
-        r.setDate(r.getDate());
         return r;
     }
 
     public static Pair pairResponseToPair(PairResponse r){
-        return new Pair(r.getPerson1(), r.getPerson2(), r.getDate());
+        return new Pair(r.getPerson1(), r.getPerson2());
     }
 
     public static List<Pair> pairResponseToPair(List<PairResponse> responses){
@@ -42,7 +41,6 @@ public class ResponsePojoConverter {
 
     public static RewardResponse rewardToRewardResponse(Reward r){
         RewardResponse res = new RewardResponse();
-        res.setDate(r.getDate());
         res.setRewardType(r.getType().toString());
         res.setUsedReward(Boolean.toString(r.isUsedReward()));
         return res;

--- a/app/src/main/java/db/responseparsers/RewardResponse.java
+++ b/app/src/main/java/db/responseparsers/RewardResponse.java
@@ -1,5 +1,6 @@
 package db.responseparsers;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -15,6 +16,7 @@ import db.RewardType;
 public class RewardResponse {
 
     @JsonProperty("date")
+    @JsonIgnore()
     private String date;
 
     @JsonProperty("reward_type")
@@ -22,16 +24,6 @@ public class RewardResponse {
 
     @JsonProperty("used_reward")
     private String used_reward;
-
-    @JsonProperty("date")
-    public String getDate() {
-        return date;
-    }
-
-    @JsonProperty("date")
-    public void setDate(String date) {
-        this.date = date;
-    }
 
     @JsonProperty("reward_type")
     public RewardType getRewardType() {


### PR DESCRIPTION
Handled by db, so does nothing in app anymore.
When app created timestamp, it was inaccurate and caused rewards to trigger one pair programming event early. 